### PR TITLE
Remove client_found_rows check

### DIFF
--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -160,7 +160,6 @@ defmodule MyXQL.Protocol do
         :client_protocol_41,
         :client_plugin_auth,
         :client_secure_connection,
-        :client_found_rows,
         :client_multi_results,
         # set by servers since 4.0
         :client_transactions


### PR DESCRIPTION
* Due to a bug in Vitess that causes this flag not to be set,
the mysql adapter should not ensure this capability